### PR TITLE
README: Update the build dependencies by adding autopoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ may need to be modified to provide shader names to the runtime.
 
 Install build dependencies:
 ```
-sudo apt install libelf-dev g++-12 llvm clang python3-mako cmake libzstd-dev
+sudo apt install libelf-dev g++-12 llvm clang python3-mako cmake libzstd-dev autopoint
 ```
 
 Clone repo and build:


### PR DESCRIPTION
The compilation fails when following the README steps because `autopoint` is missing. 
```bash
make[2]: Leaving directory '/home/dc/opensource/github/iaprof/deps/bpftool/libbpf/src'
mkdir -vp /home/dc/opensource/github/iaprof/deps/install/bpftool/lib
mkdir: created directory '/home/dc/opensource/github/iaprof/deps/install/bpftool/lib'
cp bpftool/libbpf/src/libbpf.a /home/dc/opensource/github/iaprof/deps/install/bpftool/lib/libbpf.a
mkdir -p /home/dc/opensource/github/iaprof/deps/install/libbpf/include
cp -R bpftool/src/libbpf/include/bpf /home/dc/opensource/github/iaprof/deps/install/libbpf/include
cd elfutils && autoreconf -i -f && ./configure --enable-maintainer-mode --prefix=/home/dc/opensource/github/iaprof/deps/install/libelf
Can't exec "autopoint": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 293.
autoreconf: error: autopoint failed with exit status: 2
make[1]: *** [Makefile:31: /home/dc/opensource/github/iaprof/deps/install/libelf/lib/libelf.a] Error 2
make[1]: Leaving directory '/home/dc/opensource/github/iaprof/deps'
make: *** [Makefile:10: deps] Error 2
```
Install it to fix the issue.